### PR TITLE
Fix strongSwan CI

### DIFF
--- a/tests/ci/integration/run_strongswan_integration.sh
+++ b/tests/ci/integration/run_strongswan_integration.sh
@@ -28,7 +28,7 @@ function strongswan_build() {
   # https://github.com/strongswan/strongswan/blob/44e241fccc166211ccfdd322047c1213ff3ae73c/scripts/test.sh#L468
   ./configure --disable-defaults --enable-pki --enable-openssl --enable-pem \
   --disable-dependency-tracking --enable-silent-rules --enable-test-vectors \
-  --enable-monolithic=no --enable-leak-detective=no --enable-asan
+  --enable-monolithic=no --enable-leak-detective=no --enable-asan --enable-drbg
   make -j ${NUM_CPU_THREADS}
   local openssl_plugin="${STRONGSWAN_SRC_FOLDER}/src/libstrongswan/plugins/openssl/.libs/libstrongswan-openssl.so"
   ldd ${openssl_plugin} \


### PR DESCRIPTION
### Issues:
Resolves #V1600301204

### Description of changes: 
strongSwan-6 released today and AWS-LC's job [started failing](https://github.com/aws/aws-lc/actions/runs/12141153061/job/33852603406?pr=2027). This is due to the new dependency on strongSwan's DRBG plugin to make their test vector plugin (i.e. KATs) run during a unit test run. A similar change to support this was added to the upstream CI job [here](https://github.com/strongswan/strongswan/commit/ec982171d94201065636be38199226cb57a2d45a#diff-52afcc694c0ff8ff253441f42ff44d6b4734fe30ae9070f2ba07a668a10e7baaL220)

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Assert that the strongSwan CI passes now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
